### PR TITLE
Jawn/i#140 viem

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -29,7 +29,7 @@
     "graphql": "^16.7.1",
     "graphql-tag": "^2.12.6",
     "node-cron": "^3.0.2",
-    "viem": "^1.4.1"
+    "viem": "^1.6.0"
   },
   "devDependencies": {
     "@types/node-cron": "^3.0.8",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -42,8 +42,8 @@ dependencies:
     specifier: ^3.0.2
     version: 3.0.2
   viem:
-    specifier: ^1.4.1
-    version: 1.4.1(typescript@5.1.3)
+    specifier: ^1.6.0
+    version: 1.6.0(typescript@5.1.3)
 
 devDependencies:
   '@types/node-cron':
@@ -57,7 +57,7 @@ devDependencies:
     version: 12.1.3
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.1(@types/node@20.4.2)(typescript@5.1.3)
+    version: 10.9.1(@types/node@20.5.0)(typescript@5.1.3)
   typescript:
     specifier: ^5.1.3
     version: 5.1.3
@@ -68,8 +68,8 @@ packages:
     resolution: {integrity: sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ==}
     dev: false
 
-  /@apollo/client@3.7.17(graphql@16.7.1)(subscriptions-transport-ws@0.9.19):
-    resolution: {integrity: sha512-0EErSHEtKPNl5wgWikHJbKFAzJ/k11O0WO2QyqZSHpdxdAnw7UWHY4YiLbHCFG7lhrD+NTQ3Z/H9Jn4rcikoJA==}
+  /@apollo/client@3.8.1(graphql@16.7.1)(subscriptions-transport-ws@0.9.19):
+    resolution: {integrity: sha512-JGGj/9bdoLEqzatRikDeN8etseY5qeFAY0vSAx/Pd0ePNsaflKzHx6V2NZ0NsGkInq+9IXXX3RLVDf0EotizMA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
       graphql-ws: ^5.5.5
@@ -93,20 +93,20 @@ packages:
       graphql: 16.7.1
       graphql-tag: 2.12.6(graphql@16.7.1)
       hoist-non-react-statics: 3.3.2
-      optimism: 0.16.2
+      optimism: 0.17.5
       prop-types: 15.8.1
       response-iterator: 0.2.6
       subscriptions-transport-ws: 0.9.19(graphql@16.7.1)
       symbol-observable: 4.0.0
       ts-invariant: 0.10.3
-      tslib: 2.6.0
+      tslib: 2.6.1
       zen-observable-ts: 1.2.5
     dev: false
 
   /@apollo/react-hooks@4.0.0(graphql@16.7.1)(subscriptions-transport-ws@0.9.19):
     resolution: {integrity: sha512-fCu0cbne3gbUl0QbA8X4L33iuuFVQbC5Jo2MIKRK8CyawR6PoxDpFdFA1kc6033ODZuZZ9Eo4RdeJFlFIIYcLA==}
     dependencies:
-      '@apollo/client': 3.7.17(graphql@16.7.1)(subscriptions-transport-ws@0.9.19)
+      '@apollo/client': 3.8.1(graphql@16.7.1)(subscriptions-transport-ws@0.9.19)
     transitivePeerDependencies:
       - graphql
       - graphql-ws
@@ -837,14 +837,19 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: false
 
-  /@types/node@20.4.2:
-    resolution: {integrity: sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==}
-    dev: true
+  /@types/node@20.5.0:
+    resolution: {integrity: sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==}
 
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
       '@types/node': 12.20.55
+    dev: false
+
+  /@types/ws@8.5.5:
+    resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
+    dependencies:
+      '@types/node': 20.5.0
     dev: false
 
   /@types/zen-observable@0.8.3:
@@ -865,7 +870,7 @@ packages:
   /@wry/context@0.4.4:
     resolution: {integrity: sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==}
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 20.5.0
       tslib: 1.14.1
     dev: false
 
@@ -873,7 +878,7 @@ packages:
     resolution: {integrity: sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@wry/equality@0.1.11:
@@ -886,21 +891,14 @@ packages:
     resolution: {integrity: sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
-    dev: false
-
-  /@wry/trie@0.3.2:
-    resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /@wry/trie@0.4.3:
     resolution: {integrity: sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /JSONStream@1.3.5:
@@ -2171,11 +2169,12 @@ packages:
       '@wry/context': 0.4.4
     dev: false
 
-  /optimism@0.16.2:
-    resolution: {integrity: sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==}
+  /optimism@0.17.5:
+    resolution: {integrity: sha512-TEcp8ZwK1RczmvMnvktxHSF2tKgMWjJ71xEFGX5ApLh67VsMSTy1ZUlipJw8W+KaqgOmQ+4pqwkeivY89j+4Vw==}
     dependencies:
       '@wry/context': 0.7.3
-      '@wry/trie': 0.3.2
+      '@wry/trie': 0.4.3
+      tslib: 2.6.1
     dev: false
 
   /ora@5.4.1:
@@ -2477,7 +2476,7 @@ packages:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.1
     dev: false
 
   /ts-invariant@0.4.4:
@@ -2486,7 +2485,7 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.3):
+  /ts-node@10.9.1(@types/node@20.5.0)(typescript@5.1.3):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -2505,7 +2504,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.4.2
+      '@types/node': 20.5.0
       acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -2525,8 +2524,8 @@ packages:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
     dev: false
 
-  /tslib@2.6.0:
-    resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
+  /tslib@2.6.1:
+    resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
     dev: false
 
   /tweetnacl@1.0.3:
@@ -2574,8 +2573,8 @@ packages:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: true
 
-  /viem@1.4.1(typescript@5.1.3):
-    resolution: {integrity: sha512-MtaoBHDSJDqa+QyXKG5d+S6EQSebRO0tzw6anSP4zC7AbC614vMeg9Y8LbkmEkWCw8swFYkort+H9l7GkWB0uA==}
+  /viem@1.6.0(typescript@5.1.3):
+    resolution: {integrity: sha512-ae9Twkd0q2Qlj4yYpWjb4DzYAhKY0ibEpRH8FJaTywZXNpTjFidSdBaT0CVn1BaH7O7cnX4/O47zvDUMGJD1AA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -2583,10 +2582,11 @@ packages:
         optional: true
     dependencies:
       '@adraffy/ens-normalize': 1.9.0
-      '@noble/curves': 1.0.0
+      '@noble/curves': 1.1.0
       '@noble/hashes': 1.3.0
       '@scure/bip32': 1.3.0
       '@scure/bip39': 1.2.0
+      '@types/ws': 8.5.5
       '@wagmi/chains': 1.6.0(typescript@5.1.3)
       abitype: 0.9.3(typescript@5.1.3)
       isomorphic-ws: 5.0.0(ws@8.12.0)

--- a/backend/watch/watchDatabaseEvents.ts
+++ b/backend/watch/watchDatabaseEvents.ts
@@ -1,18 +1,19 @@
-import { parseAbiItem, type Hex } from 'viem'
+import { parseAbi, type Hex } from 'viem'
 import { decodeLogs } from '../transform/decodeLogs'
 import { viemClient } from '../viem/client'
 import { databaseAbiEventsArray } from '../constants/events'
 import { writeToDatabase } from '../prisma'
 
+
 export const watchDatabaseEvents = () => {
-  databaseAbiEventsArray.forEach((event: string) => {
-    const parsedEvent = parseAbiItem([event])
+    const parsedEvent = parseAbi(databaseAbiEventsArray)
     viemClient.watchEvent({
       address: process.env.DATABASE_ADDRESS as Hex,
-      event: parsedEvent,
+      events: parsedEvent,
       onLogs: (logs) => {
         writeToDatabase(decodeLogs(logs))
-      },
+        console.log("Decoded logs:", decodeLogs(logs));
+      }
     })
-  })
-}
+  }
+  watchDatabaseEvents()

--- a/frontend/apps/next/app/page.tsx
+++ b/frontend/apps/next/app/page.tsx
@@ -17,25 +17,34 @@ export default function Page() {
         <Flex className='w-full justify-center mb-6'>
           <FunctioNav />
         </Flex>
-        <Grid className='grid-rows-2 grid-cols-8 gap-4'>
-          {/* Row 1 */}
-          <div className='row-start-1 row-end-2 col-start-1 col-end-7 flex gap-4'>
-            <div className='bg-[#16171A] border border-arsenic w-6/12 h-full rounded-xl'>
+        <div className='flex flex-col lg:flex-row gap-4'>
+          <div className='flex flex-col lg:flex-row gap-4 mb-4 w-full'>
+            {/* Code Viewers */}
+            <div className='bg-[#16171A] border border-arsenic w-full lg:w-1/2 rounded-xl mb-4 lg:mb-0'>
               <CodeViewer language={'typescript'} />
             </div>
-            <div className='bg-[#16171A]  border border-arsenic w-6/12 h-full rounded-xl'>
+            <div className='bg-[#16171A] border border-arsenic w-full lg:w-1/2 rounded-xl'>
               <CodeViewer language={'solidity'} />
             </div>              
-          </div>          
-          <div className='col-start-7 col-end-9 row-start-1 row-end-2'>
-            <div className='bg-[#16171A] text-white border border-arsenic w-full h-full rounded-xl'>
+          </div>
+
+          {/* Transaction Submitter */}
+          <div className='bg-[#16171A] text-white border border-arsenic w-full lg:w-1/4 rounded-xl mb-4'>
             <TxnSubmitter />
-            </div>
-          </div>            
-          {/* Row 2 */}
-          <RawTransactionsTable className='' />
-          <ArweaveBox className='border border-arsenic w-full h-full rounded-xl' />
-        </Grid>
+          </div>
+        </div>
+
+        <div className='flex flex-col lg:flex-row gap-4'>
+          {/* Raw Transactions Table */}
+          <div className='w-full lg:w-3/4'>
+            <RawTransactionsTable />
+          </div>
+
+          {/* Arweave Box */}
+          <div className='w-1/2 h-1/2 p-2' >
+          <ArweaveBox className='max-w-screen-sm rounded-xl'/>
+          </div>
+        </div>
       </main>
       <Footer />
     </VStack>    

--- a/frontend/apps/next/components/arweave/ArweaveBox.tsx
+++ b/frontend/apps/next/components/arweave/ArweaveBox.tsx
@@ -47,7 +47,7 @@ export const ArweaveBox = async ({ className }: ArweaveBoxProps) => {
   if (!arweaveData) return null; 
 
   return (
-    <Flex className='row-start-2 row-end-3 col-start-6 col-end-9 flex-col w-full content-between border border-arsenic rounded-xl px-6 py-3'>
+    <Flex className='row-start-2 row-end-3 col-start-6 col-end-9 flex-col w-full content-between rounded-xl px-6 py-3'>
          <CaptionLarge className='text-platinum mb-4 align-left'>Arweave Backups</CaptionLarge> 
       {arweaveData.map((arweave) => (
         <ArweaveComponent key={arweave.link} arweave={arweave} />

--- a/frontend/apps/next/components/server/RawTransactionsTable.tsx
+++ b/frontend/apps/next/components/server/RawTransactionsTable.tsx
@@ -74,7 +74,7 @@ const RawTransactionComponent = ({
   className,
 }: RawTransactionComponentProps) => (
   <Grid className='grid-cols-3 items-center my-2'>
-    <EventType rawTransactions={rawTransactions.eventType} />
+    <EventType className='justify-center sm:flex-row' rawTransactions={rawTransactions.eventType} />
     <Flex className='justify-center'>
       <RawTransactionField rawTransactions={rawTransactions.createdAt} />
     </Flex>

--- a/frontend/packages/ap-hooks/.turbo/turbo-build.log
+++ b/frontend/packages/ap-hooks/.turbo/turbo-build.log
@@ -1,19 +1,19 @@
 
-> @public-assembly/ap-hooks@0.0.1 build /Users/maximbochman/Desktop/code/ap-demo-230814/frontend/packages/ap-hooks
+> @public-assembly/ap-hooks@0.0.1 build /Users/lreyes/Desktop/Github/assembly-press/frontend/packages/ap-hooks
 > tsup src/index.ts --format esm,cjs --dts --external react
 
 CLI Building entry: src/index.ts
 CLI Using tsconfig: tsconfig.json
 CLI tsup v7.1.0
-CLI Using tsup config: /Users/maximbochman/Desktop/code/ap-demo-230814/frontend/packages/ap-hooks/tsup.config.ts
+CLI Using tsup config: /Users/lreyes/Desktop/Github/assembly-press/frontend/packages/ap-hooks/tsup.config.ts
 CLI Target: node16
 ESM Build start
 CJS Build start
-CJS dist/index.js 17.18 KB
-CJS ⚡️ Build success in 11ms
 ESM dist/index.mjs 16.42 KB
-ESM ⚡️ Build success in 11ms
+ESM ⚡️ Build success in 13ms
+CJS dist/index.js 17.18 KB
+CJS ⚡️ Build success in 13ms
 DTS Build start
-DTS ⚡️ Build success in 1404ms
+DTS ⚡️ Build success in 1412ms
 DTS dist/index.d.mts 2.68 KB
 DTS dist/index.d.ts  2.68 KB


### PR DESCRIPTION
watchEvents now properly uses events: parsedEvent instead of the work around we initially had. 